### PR TITLE
Fixes for create node groups, v1.0 API (4.2.1) - environment_trumps

### DIFF
--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -84,8 +84,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
     end
     # namevar may not be in this hash 
     send_data['name'] = @resource[:name] unless send_data['name']
-    # key changed for usability
-    send_data['override_environment'] = send_data['environment_trumps'] if send_data['environment_trumps']
+    
     # Passing an empty hash in the type results in undef
     send_data['classes'] = {} unless send_data['classes']
 
@@ -97,9 +96,15 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
       end
     end
 
+    #renamed key for v1.0 API... 
+    send_data['environment_trumps'] = send_data.delete('override_environment')
+    send_data['environment_trumps'] = false if !send_data['environment_trumps']
+
     resp = $puppetclassify.groups.create_group(send_data)
     if resp
       send_data.each_key do |k|
+        #renamed key for v1.0 API...
+        k = 'override_environment' if k == 'environment_trumps'
         @property_hash[k]       = @resource[k]
         @property_hash[:ensure] = :present
       end

--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -77,6 +77,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
   mk_resource_methods
 
   def create
+    @noflush = true
     # Only passing parameters that are given
     send_data = Hash.new
     @resource.original_parameters.each do |k,v|
@@ -166,6 +167,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
   end
 
   def flush
+    return if @noflush
     debug @property_flush['attrs']
     if @property_flush['attrs']
       @property_flush['attrs']['id'] = @property_hash[:id] unless @property_flush['attrs']['id']

--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -28,13 +28,8 @@ Puppet::Type.newtype(:node_group) do
       fail("Variables must be supplied as a hash") unless value.is_a?(Hash)
     end
   end
-  newproperty(:rule) do
+  newproperty(:rule, :array_matching => :all) do
     desc 'Match conditions for this group'
-    flat = []
-    munge do |value|
-      flat << value
-    end
-    flat.join(',')
   end
   newproperty(:environment) do
     desc 'Environment for this group'


### PR DESCRIPTION
An error occured creating the group: HTTP 400 Bad Request
``` 
Error: puppetclassify was not able to create group
Error: /Stage[main]/Profile::Master_classifier/Node_group[this will fail]/ensure: change from absent to present failed: puppetclassify was not able to create group
```
The malformed request contains invalid key which is one of the friendly keys: override_environment
https://docs.puppetlabs.com/pe/latest/nc_groups.html#post-v1groups  specifies "environment_trumps".

(Although this is still soft failing at updating non-existing groups [something to do with flushing, a 404 is returned on the first run - subsequent runs are fine - I can't yet see where it's failing - some where here ->  
``` 
def flush
    debug @property_flush['attrs']
    if @property_flush['attrs']
      @property_flush['attrs']['id'] = @property_hash[:id] unless @property_flush['attrs']['id']
      begin
        $puppetclassify.groups.update_group(@property_flush['attrs'])
      rescue Exception => e
        fail(e.message)
        debug(e.backtrace.inspect)
      else).
``` 