### PR TITLE
Add support for rbac_user passwords

### DIFF
--- a/lib/puppet/provider/rbac_user/rbac_user.rb
+++ b/lib/puppet/provider/rbac_user/rbac_user.rb
@@ -17,6 +17,7 @@ Puppet::Type.type(:rbac_user).provide(:rbac_user, :parent => Puppet::Provider::R
       :is_superuser => 'superuser',
       :last_login   => 'last_login',
       :role_ids     => 'role_ids',
+      :password     => 'password'
     }
   end
 
@@ -65,6 +66,7 @@ Puppet::Type.type(:rbac_user).provide(:rbac_user, :parent => Puppet::Provider::R
     debug send_data
     friendlies = Puppet::Type::Rbac_user::ProviderRbac_user.friendly_name
     data = Helpers.data_hash(send_data, friendlies)
+    puts data.inspect
     resp = Puppet::Type::Rbac_user::ProviderRbac_user.rest('POST', 'users', data)
 
     send_data.each_key do |k|

--- a/lib/puppet/provider/rbac_user/rbac_user.rb
+++ b/lib/puppet/provider/rbac_user/rbac_user.rb
@@ -66,7 +66,6 @@ Puppet::Type.type(:rbac_user).provide(:rbac_user, :parent => Puppet::Provider::R
     debug send_data
     friendlies = Puppet::Type::Rbac_user::ProviderRbac_user.friendly_name
     data = Helpers.data_hash(send_data, friendlies)
-    puts data.inspect
     resp = Puppet::Type::Rbac_user::ProviderRbac_user.rest('POST', 'users', data)
 
     send_data.each_key do |k|

--- a/lib/puppet/type/rbac_user.rb
+++ b/lib/puppet/type/rbac_user.rb
@@ -26,6 +26,12 @@ Puppet::Type.newtype(:rbac_user) do
       fail("#{name} is not a valid group name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
     end
   end
+  newproperty(:password) do
+    desc 'The user\'s password'
+    validate do |value|
+      fail("#{name} is not a valid group name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+    end
+  end
   newproperty(:remote) do
     desc ''
     newvalues(:false, :true)


### PR DESCRIPTION
Previous to this commit, passwords could not be set for new RBAC users
despite being supported in the API.  This commit adds support for
setting passwords, but only when users are created.  Updating passwords
for existing accounts is not supported