### PR TITLE
Support certname lookup for RBAC URL

### DIFF
--- a/lib/puppet/provider/helpers.rb
+++ b/lib/puppet/provider/helpers.rb
@@ -20,7 +20,7 @@ require 'openssl'
         port   = nc_settings['port']
       end
     when 'rbac-api'
-      server = 'puppet'
+      server = Puppet.settings.setting('certname').value
       port   = '4433'
     end
 


### PR DESCRIPTION
Previous to this commit, the RBAC DNS name was hard coded to puppet.
For environemnts where that's not the DNS hostname of the puppet master,
this fails.

This commit grabs the certname setting from the Puppet config and
assumes that's the correct DNS name to use since Puppet is likely not
functioning if that's not the hostname. This restricts the solution to
working on the master for monolithic installs.

There have to be better solutions available, however.  I haven't found
where to lookup the URL configuration for the RBAC service.