### PR TITLE
Guard Puppetclassify usage with a Puppet feature

### DIFF
--- a/lib/puppet/feature/puppetclassify.rb
+++ b/lib/puppet/feature/puppetclassify.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:puppetclassify, :libs => ['puppetclassify'])


### PR DESCRIPTION
The `node_group` resource requires the Puppetclassify gem to be installed.
However, `node_group` could not be used in a catalog that also installs the
required gem as autoloading the provider would cause a failed attempt to load
the gem.

This patch properly guards the use of Puppetclassify by adding
`:puppetclassify` to `Puppet.features` and using the feature to
confine the provider. The provider class has also been re-factored to
store the shared PuppetClassifier instance in a class variable instead
of using a global variable.