### PR TITLE
Allow colons in node group names

### DIFF
--- a/lib/puppet/type/node_group.rb
+++ b/lib/puppet/type/node_group.rb
@@ -5,7 +5,7 @@ Puppet::Type.newtype(:node_group) do
   newparam(:name, :namevar => true) do
     desc 'This is the common name for the node group'
     validate do |value|
-      fail("#{name} is not a valid group name") unless value =~ /^[a-zA-Z0-9\-\_'\s]+$/
+      fail("#{name} is not a valid group name") unless value =~ /^[a-zA-Z0-9:\-\_'\s]+$/
     end
   end
   newproperty(:id) do


### PR DESCRIPTION
A colon is a valid character there.  Prior to this, the node_group
resource would fail for groups with a colon in their name because the
validation regex did not allow for a colon.

This is especially relevant when node group names match a class name,
such as a 'role' class with colons for namespacing.