### PR TITLE
Updating docs to pass show passing a boolean value for override_envir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ node_group { 'PE MCollective':
   classes              => {'puppet_enterprise::profile::mcollective::agent' => {}},
   environment          => 'production',
   id                   => '4cdec347-20c6-46d7-9658-7189c1537ae9',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['and', ['~', ['fact', 'pe_version'], '.+']],
 }

--- a/docs/PE_groups.md
+++ b/docs/PE_groups.md
@@ -4,7 +4,7 @@ node_group { 'PE ActiveMQ Broker':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::amq::broker' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['or', ['=', 'name', 'master.puppetlabs.vm']],
 }
@@ -12,7 +12,7 @@ node_group { 'PE Certificate Authority':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::certificate_authority' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['or', ['=', 'name', 'master.puppetlabs.vm']],
 }
@@ -20,7 +20,7 @@ node_group { 'PE Console':
   ensure               => 'present',
   classes              => {'pe_console_prune' => {'prune_upto' => '30'}, 'puppet_enterprise::license' => {}, 'puppet_enterprise::profile::console' => {}, 'puppet_enterprise::profile::mcollective::console' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['or', ['=', 'name', 'master.puppetlabs.vm']],
 }
@@ -28,14 +28,14 @@ node_group { 'PE Infrastructure':
   ensure               => 'present',
   classes              => {'puppet_enterprise' => {'certificate_authority_host' => 'master.puppetlabs.vm', 'console_host' => 'master.puppetlabs.vm', 'console_port' => '443', 'database_host' => 'master.puppetlabs.vm', 'database_port' => '5432', 'database_ssl' => 'true', 'mcollective_middleware_hosts' => ['master.puppetlabs.vm'], 'puppet_master_host' => 'master.puppetlabs.vm', 'puppetdb_database_name' => 'pe-puppetdb', 'puppetdb_database_user' => 'pe-puppetdb', 'puppetdb_host' => 'master.puppetlabs.vm', 'puppetdb_port' => '8081'}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'default',
 }
 node_group { 'PE MCollective':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::mcollective::agent' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['and', ['~', ['fact', 'pe_version'], '.+']],
 }
@@ -43,7 +43,7 @@ node_group { 'PE Master':
   ensure               => 'present',
   classes              => {'pe_repo' => {}, 'pe_repo::platform::el_6_x86_64' => {}, 'puppet_enterprise::profile::master' => {}, 'puppet_enterprise::profile::master::mcollective' => {}, 'puppet_enterprise::profile::mcollective::peadmin' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['or', ['=', 'name', 'master.puppetlabs.vm']],
 }
@@ -51,7 +51,7 @@ node_group { 'PE PuppetDB':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::puppetdb' => {}},
   environment          => 'production',
-  override_environment => 'false',
+  override_environment => false,
   parent               => 'PE Infrastructure',
   rule                 => ['or', ['=', 'name', 'master.puppetlabs.vm']],
 }


### PR DESCRIPTION
The current docs list passing a sting false for the override_environment parameter.  This causes a failure in creating new groups, which look like was a result of PR #5 or #11 


Error when sending false as a string
````
An error occured creating the group: HTTP 400 Bad Request
{"kind":"schema-violation","msg":"The object(s) in your submitted request did not conform to the schema. The problem is: ([:environment-trumps (not (instance? Boolean \"false\"))])","details":
````