### PR TITLE
(Issue #18) Implement parser function to list available classes

### DIFF
--- a/lib/puppet/parser/functions/environment_classes.rb
+++ b/lib/puppet/parser/functions/environment_classes.rb
@@ -1,0 +1,11 @@
+Puppet::Parser::Functions.newfunction(:environment_classes, :arity => 0, :type => :rvalue) do |values|
+  # Make sure we've parsed and evaluated every class
+  # available in the environment.
+  environment.check_for_reparse
+  environment.known_resource_types.loader.import_all
+
+  classes = environment.known_resource_types.hostclasses.map {|name, hostclass| hostclass.name }
+  classes.delete("")
+
+  return classes
+end

--- a/lib/puppet/parser/functions/environment_classes.rb
+++ b/lib/puppet/parser/functions/environment_classes.rb
@@ -1,10 +1,19 @@
-Puppet::Parser::Functions.newfunction(:environment_classes, :arity => 0, :type => :rvalue) do |values|
+Puppet::Parser::Functions.newfunction(:environment_classes, :arity => -1, :type => :rvalue) do |values|
+  env_name = values[0]
+
+  if env_name
+    env = Puppet.lookup(:environments).get!(env_name)
+  else
+    # If no environment was provided, use this node's
+    env = environment
+  end
+
   # Make sure we've parsed and evaluated every class
   # available in the environment.
-  environment.check_for_reparse
-  environment.known_resource_types.loader.import_all
+  env.check_for_reparse
+  env.known_resource_types.loader.import_all
 
-  classes = environment.known_resource_types.hostclasses.map {|name, hostclass| hostclass.name }
+  classes = env.known_resource_types.hostclasses.map {|name, hostclass| hostclass.name }
   classes.delete("")
 
   return classes

--- a/spec/unit/puppet/parser/functions/environment_classes_spec.rb
+++ b/spec/unit/puppet/parser/functions/environment_classes_spec.rb
@@ -1,0 +1,17 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+describe "the environment_classes function" do
+  let(:the_node)     { Puppet::Node.new('stub_node') }
+  let(:the_compiler) { Puppet::Parser::Compiler.new(the_node) }
+  let(:the_scope)    { Puppet::Parser::Scope.new(the_compiler) }
+  let(:the_typecollection) { Puppet::Resource::TypeCollection.new(the_scope.environment) }
+
+  it "should return all available class names without any empty strings" do
+    the_typecollection << Puppet::Resource::Type.new(:hostclass, :stub_class_1)
+    the_typecollection << Puppet::Resource::Type.new(:hostclass, :stub_class_2)
+    the_typecollection << Puppet::Resource::Type.new(:hostclass, '')
+
+    col = the_scope.environment.stubs(:known_resource_types).returns(the_typecollection)
+    expect(the_scope.function_environment_classes([])).to eq(["stub_class_1", "stub_class_2"])
+  end
+end


### PR DESCRIPTION
This is an implementation of the design suggested by @smbambling in issue #18.

I'm not convinced that the node manager module is the best place for this function, but I believe it could enable some compelling design patterns. What do you think @WhatsARanjit? Better suited for another module? Stdlib?

If we end up keeping the function in this module, I'll add an appropriate stanza to the README.