### PR TITLE
fixed the validation of puppet_environment validation on agent-specif…

### DIFF
--- a/lib/puppet/type/puppet_environment.rb
+++ b/lib/puppet/type/puppet_environment.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:puppet_environment) do
   newparam(:name, :namevar => true) do
     desc 'This is the name of the environment'
     validate do |value|
-      fail("#{value} is not a valid group name") unless value =~ /\A[a-z0-9_]+\Z/
+      fail("#{value} is not a valid group name") unless value =~ /\A[a-z0-9_-]+\Z/
     end
   end
 end


### PR DESCRIPTION
[root@pe-201523-master modules]# puppet resource puppet_environment
Error: Could not run: Parameter name failed on Puppet_environment[agent-specified]: agent-specified is not a valid group name

Fixed the regex validating the environments name.