### PR TITLE
Fix metaparameter bug

### DIFF
--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -90,6 +90,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
     send_data = Hash.new
     @resource.original_parameters.each do |k,v|
       next if k == :ensure
+      next if @resource.parameter(k).metaparam?
       key = k.to_s
       # key changed for usability
       key = 'environment_trumps' if key == 'override_environment'


### PR DESCRIPTION
Previously, due to dynamism in building the JSON data to send to the NC
API, when metaparameters like "require" and "subscribe" were passed to
node_group resources those parameter keys would end up in the JSON send
to the NC - specifically in the create() method of the provider. This
resulted in the provider being unable to create resources if they had
metaparameters specified.

This commit fixes the problem and allows require, subscribe, and more to
be specified by discarding metaparameters when building the create JSON.