### PR TITLE
Do not require 'puppetclassify' to compile

### DIFF
--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -1,7 +1,17 @@
-require 'puppetclassify'
-require 'yaml'
+# The provider is loaded both by the master and by the agent. Only the agent
+# will actually need the puppetclassify gem and methods. In order to allow
+# seamless loading by the masteror during compilation prior to enforcing state,
+# allow graceful failure when unable to load puppetclassify.
 
-class Puppet::Util::Node_groups < PuppetClassify
+begin
+  require 'yaml'
+  require 'puppetclassify'
+  parent = PuppetClassify
+rescue LoadError => e
+  parent = Object
+end
+
+class Puppet::Util::Node_groups < parent
   attr_reader :groups
   alias_method :groups, :groups
 


### PR DESCRIPTION
There is no functional requirement for the puppetclassify gem to be installed in order to compile a catalog that includes node_group types. This commit modifies the code such that the compilation process will not fail if puppetclassify is not yet installed. This enables the bootstrap use case, where the master can in a single Puppet run install the puppetclassify gem on itself and then use it to configure the classifier.