### PR TITLE
Fix $ngs caching when creating new groups

### DIFF
--- a/lib/puppet/provider/node_group/puppetclassify.rb
+++ b/lib/puppet/provider/node_group/puppetclassify.rb
@@ -105,7 +105,7 @@ Puppet::Type.type(:node_group).provide(:puppetclassify) do
         end
       end
       # Add placeholder for $ngs lookups
-      $ngs << { "name" => send_data[:name], "id" => resp }
+      $ngs << { "name" => send_data['name'], "id" => resp }
     else
       fail("puppetclassify was not able to create group")
     end


### PR DESCRIPTION
Previously, the $ngs global would not be populated with newly created group IDs because of an incorrect hash index. send_data[:name] was referenced, which was nil, rather than send_data['name']. This made it impossible to create a parent group and then create child groups for that parent during the same Puppet run.

This commit fixes the problem.