### PR TITLE
Add maintainers section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,9 @@ Retrieve all or one node_group and its data.
   ```
 
 _Type:_ rvalue
+
+## Maintainers
+This repositority is largely the work of the Puppet Labs Professional Services
+team.  It is not officially maintained by Puppet Labs, or any individual in
+particular.  Issues should be opened in github.  Questions should be directed
+at the individuals responsible for committing that particular code.


### PR DESCRIPTION
This commit simply adds a "Maintainers" section to the README file, to bring this repository into compliance with the guidelines posted on our internal wiki.