### PR TITLE
Fix inheritance code for Puppet::Util::Node_groups

### DIFF
--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -12,9 +12,6 @@ rescue LoadError => e
 end
 
 class Puppet::Util::Node_groups < parent
-  attr_reader :groups, :environments
-  alias_method :groups, :groups
-  alias_method :environments, :environments
 
   def initialize
     auth_info = {
@@ -31,14 +28,7 @@ class Puppet::Util::Node_groups < parent
       classifier_url = "https://#{nc_settings['server']}:#{nc_settings['port']}/classifier-api"
     end
 
-    ng            = PuppetClassify.new(classifier_url, auth_info)
-    @groups       = ng.groups
-    @environments = ng.environments
-
-    # Add in for delete_environment method.
-    # See below.
-    @auth_info    = auth_info
-    @nc_api_url   = classifier_url
+    super(classifier_url, auth_info)
   end
 
   # Transform the node group array in to a hash
@@ -58,8 +48,7 @@ class Puppet::Util::Node_groups < parent
   # method to delete environments.  Using this
   # in the meantime.
   def delete_environment(name)
-    puppet_https = PuppetHttps.new(@auth_info)
-    env_res = puppet_https.delete("#{@nc_api_url}/v1/environments/#{name}")
+    env_res = @puppet_https.delete("#{@nc_api_url}/v1/environments/#{name}")
 
     unless env_res.code.to_i == 204
       STDERR.puts "An error occured saving the environment: HTTP #{env_res.code} #{env_res.message}"


### PR DESCRIPTION
Previously this class did not completely inherit the functionality of
its parent, and in implemented several measures that gave it some parent
functionality but not all.

This commit modifies the inheritance code to make the child object a
fully-functional PuppetClassify object in addition to its own special
functionality, and reduces complexity and LOC at the same time.