### PR TITLE
Make library require statement more robust

### DIFF
--- a/lib/puppet/parser/functions/node_groups.rb
+++ b/lib/puppet/parser/functions/node_groups.rb
@@ -1,4 +1,9 @@
-require 'puppet/util/node_groups'
+begin
+  require 'puppet/util/node_groups'
+rescue LoadError
+  mod = Puppet::Module.find('node_manager', Puppet[:environment].to_s)
+  require File.join mod.path, 'lib/puppet/util/node_groups'
+end
 
 module Puppet::Parser::Functions
   newfunction(:node_groups, :type => :rvalue) do |args|


### PR DESCRIPTION
Previously, there seemed to be some weird edge conditions under which
puppet would return a load error, e.g. if running in `apply` mode, while
at the same time would work correctly when running under puppetserver.
This commit implements a begin/rescue pattern that is used in several
other Puppet modules on the Forge to successfully load the library in
all known circumstances.