### PR TITLE
Update for new PE version and new puppetclassify by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,10 +1,10 @@
 class node_manager::params {
-  $version = '0.1.3' #puppetclassify gem version
+  $version = '0.1.5' #puppetclassify gem version
 
   if "$::puppetversion" =~ /3.8/ {
     $gemprovider='pe_gem'
   }
-  elsif "$::pe_server_version" =~ /2015/ {
+  elsif "$::pe_server_version" =~ /2015/ or "$::pe_server_version" =~ /2016/ {
     $gemprovider = 'puppet_gem'
   }
   else {


### PR DESCRIPTION
It is easy enough to override the params in the install class, but it might be convenient to update the defaults.