### PR TITLE
Making  fix for 2016.5.1

### DIFF
--- a/lib/puppet/util/node_groups.rb
+++ b/lib/puppet/util/node_groups.rb
@@ -22,6 +22,7 @@ class Puppet::Util::Node_groups < parent
 
     begin
       nc_settings = YAML.load_file("#{Puppet.settings['confdir']}/classifier.yaml")
+      nc_settings = nc_settings.first if nc_settings.class == Array            
     rescue
       fail "Could not find file #{Puppet.settings['confdir']}/classifier.yaml"
     else


### PR DESCRIPTION
The classifier.yaml contains an array. So if it's an array set nc_settings to the first element. Mirroring changes made in this similar commit
https://github.com/puppetlabs/pltraining-rbac/commit/3ad787e3077fe7b14b2e8362a889bbbb74b8263d