### PR TITLE
Added 2016 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class node_manager::params {
   if "$::puppetversion" =~ /3.8/ {
     $gemprovider='pe_gem'
   }
-  elsif "$::pe_server_version" =~ /2015/ {
+  elsif "$::pe_server_version" =~ /201[56]/ {
     $gemprovider = 'puppet_gem'
   }
   else {


### PR DESCRIPTION
In this commit, I altered the regex to check for both 2015.x.x and
2016.x.x for puppet_gem usage.