### PR TITLE
Fix markdown rendering issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# node_manager [![Build Status](https://travis-ci.org/puppetlabs/prosvcs-node_manager.svg)](https://travis-ci.org/puppetlabs/prosvcs-node_manager)
+# node\_manager [![Build Status](https://travis-ci.org/puppetlabs/prosvcs-node_manager.svg)](https://travis-ci.org/puppetlabs/prosvcs-node_manager)
 
 #### Table of Contents
+
 1. [Overview](#overview)
-1. [Requirements] (#requirements)
-1. [Types] (#types)
-  * [Node_group] (#node_group)
-  * [Puppet_environment] (#puppet_environment)
-1. [Functions] (#functions)
-  * [node_groups()] (#node_groups)
+1. [Requirements](#requirements)
+1. [Types](#types)
+    * [Node\_group](#node_group)
+    * [Puppet\_environment](#puppet_environment)
+1. [Functions](#functions)
+    * [node\_groups()](#node_groups)
 
 ## Overview
 
@@ -15,32 +16,36 @@ Create and manage Node Manager API endpoints as resources.
 
 ## Module State
 
-NOTE: This module is a Professional Service side project and is currently unmaintained. 
+NOTE: This module is a Professional Service side project and is currently unmaintained.
 It is not supported and may not function as expected.
 
-## Requirements:
+## Requirements
 
-- *nix operating system
-- Puppet >= 3.7.1  
-- [puppetclassify](https://github.com/puppetlabs/puppet-classify) gem
-- [puppetlabs/pe_gem module](https://forge.puppetlabs.com/puppetlabs/pe_gem)
+* *nix operating system
+* Puppet >= 3.7.1
+* [puppetclassify](https://github.com/puppetlabs/puppet-classify) gem
+* [puppetlabs/pe_gem module](https://forge.puppetlabs.com/puppetlabs/pe_gem)
 
 ## Classes
-### Node_manager
+
+### Node\_manager
+
 The node_manager class facilitates the deployment of the puppetclassify gem
 simply include node_manager in your node definition or add it to the pe_master node group
 
 ## Types
 
-### Node_group
+### Node\_group
 
 Node_groups will autorequire parent node_groups.
 
 Enumerate all node groups:
-* `puppet resource node_group`<br />
+
+* `puppet resource node_group`
 
 Example output for `puppet resource node_group 'PE MCollective'`
-```
+
+```puppet
 node_group { 'PE MCollective':
   ensure               => 'present',
   classes              => {'puppet_enterprise::profile::mcollective::agent' => {}},
@@ -52,57 +57,75 @@ node_group { 'PE MCollective':
 }
 ```
 
-#### Node_group parameters
+#### Node\_group parameters
 
-* `classes`<br />
-Classes that are assigned to the node in hash format.  Elements of the hash
-are class parameters. Default (empty hash): `{}`
+* `classes`
 
-* `environment`<br />
-Environment selected for this node group. Default: `production`
+  Classes that are assigned to the node in hash format. Elements of the hash are class parameters.
 
-* `name`<br />
-(namevar) Node group's name.
+  Default (empty hash): `{}`
 
-* `id`<br />
-Universal ID for the group. This attribute is read-only.
+* `environment`
 
-* `override_environment`<br />
-Whether or not this group's environment ment setting overrides
-all other other environments. Default: `false`
+  Environment selected for this node group.
 
-* `parent`<br />
-The UID for the data group. Can be specified by group name or
-UID. Default: `default`
+  Default: `production`
 
-* `rules`<br />
-An array of classification rules. Default (empty array): `[]`
+* `name`
 
-### Puppet_environment
+  (namevar) Node group's name.
+
+* `id`
+
+  Universal ID for the group. This attribute is read-only.
+
+* `override_environment`
+
+  Whether or not this group's environment ment setting overrides all other other environments.
+
+  Default: `false`
+
+* `parent`
+
+  The UID for the data group. Can be specified by group name or UID.
+
+  Default: `default`
+
+* `rules`
+
+  An array of classification rules.
+
+  Default (empty array): `[]`
+
+### Puppet\_environment
 
 Enumerate all puppet environments:
-* `puppet resource puppet_environment`<br />
+
+* `puppet resource puppet_environment`
 
 Example output for `puppet resource puppet_environment production`
-```
+
+```puppet
 puppet_environment { 'production':
   ensure => 'present',
 }
 ```
-#### Puppet_environment parameters
 
-* `name`<br />
-(namevar) Name of the Puppet environment on disk, i.e. the directory name in `$environmentpath`.
+#### Puppet\_environment parameters
+
+* `name`
+
+  (namevar) Name of the Puppet environment on disk, i.e. the directory name in `$environmentpath`.
 
 ## Functions
 
-### node_groups()
+### node\_groups()
 
 Retrieve all or one node_group and its data.
 
 `node_groups()` will return:
 
-```
+```puppet
 {
   "default"=>{
     "environment_trumps"=>false,
@@ -129,7 +152,7 @@ Retrieve all or one node_group and its data.
 
 `node_groups('default')` will return:
 
-```
+```puppet
 {
   "default"=>{
     "environment_trumps"=>false,
@@ -146,7 +169,9 @@ Retrieve all or one node_group and its data.
 _Type:_ rvalue
 
 ## Maintainers
+
 This repositority is largely the work of the Puppet Labs Professional Services
-team.  It is not officially maintained by Puppet Labs, or any individual in
-particular.  Issues should be opened in github.  Questions should be directed
+team. It is not officially maintained by Puppet Labs, or any individual in
+particular. Issues should be opened in github. Questions should be directed
 at the individuals responsible for committing that particular code.
+


### PR DESCRIPTION
Prior to this there were a few issues with how the README was rendered
on GitHub and the Forge. This commit fixes the following:

* Table of contents links
* Code block syntax highlighting
* list indentation
* Other minor markdown syntax fixes